### PR TITLE
Add configurable start date for interest periods

### DIFF
--- a/index.html
+++ b/index.html
@@ -399,6 +399,10 @@
                     <label for="interestRate">Tipo de Interés Anual (%)</label>
                     <input type="number" id="interestRate" placeholder="Ej: 5.5" step="0.01">
                 </div>
+                <div class="form-group">
+                    <label for="startDate">Fecha de inicio para el cálculo</label>
+                    <input type="date" id="startDate">
+                </div>
                 <button onclick="saveConfig()">Guardar Configuración</button>
             </div>
         </div>
@@ -409,6 +413,7 @@
         let appState = {
             creditLimit: 0,
             interestRate: 0,
+            startDate: '',
             transactions: []
         };
 
@@ -417,17 +422,18 @@
             const saved = localStorage.getItem('creditLineState');
             if (saved) {
                 appState = JSON.parse(saved);
+                if (!appState.startDate) appState.startDate = '';
                 updateUI();
-            
-            // Si no hay configuración inicial, mostrar aviso
-            if (!appState.creditLimit || !appState.interestRate) {
-                setTimeout(() => {
-                    const warningElement = document.getElementById('noConfigWarning');
-                    if (warningElement && warningElement.style.display === 'block') {
-                        warningElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
-                    }
-                }, 1000);
-            }
+
+                // Si no hay configuración inicial, mostrar aviso
+                if (!appState.creditLimit || !appState.interestRate) {
+                    setTimeout(() => {
+                        const warningElement = document.getElementById('noConfigWarning');
+                        if (warningElement && warningElement.style.display === 'block') {
+                            warningElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                        }
+                    }, 1000);
+                }
             }
         }
 
@@ -484,6 +490,7 @@
         function saveConfig() {
             const creditLimit = parseFloat(document.getElementById('creditLimit').value);
             const interestRate = parseFloat(document.getElementById('interestRate').value);
+            const startDate = document.getElementById('startDate').value;
 
             if (!creditLimit || !interestRate) {
                 alert('Por favor, completa todos los campos de configuración');
@@ -492,6 +499,7 @@
 
             appState.creditLimit = creditLimit;
             appState.interestRate = interestRate;
+            appState.startDate = startDate;
             saveState();
             updateUI();
             
@@ -641,24 +649,48 @@
             return totalInterest;
         }
 
+        // Sumar meses a una fecha
+        function addMonths(date, months) {
+            const d = new Date(date);
+            d.setMonth(d.getMonth() + months);
+            return d;
+        }
+
+        // Obtener información del trimestre que contiene la fecha indicada
+        function getQuarterInfo(referenceDate) {
+            if (!appState.startDate) {
+                const quarter = Math.floor(referenceDate.getMonth() / 3) + 1;
+                const startMonth = (quarter - 1) * 3;
+                const start = new Date(referenceDate.getFullYear(), startMonth, 1);
+                const end = new Date(referenceDate.getFullYear(), startMonth + 3, 0);
+                return { year: referenceDate.getFullYear(), quarter, start, end };
+            }
+
+            const firstStart = new Date(appState.startDate);
+            let start = new Date(firstStart);
+            while (addMonths(start, 3) <= referenceDate) {
+                start = addMonths(start, 3);
+            }
+            const end = addMonths(start, 3);
+            end.setDate(end.getDate() - 1);
+            const quarter = Math.floor(start.getMonth() / 3) + 1;
+            const year = start.getFullYear();
+            return { year, quarter, start, end };
+        }
+
         // Obtener trimestre actual
         function getCurrentQuarter() {
-            const now = new Date();
-            const quarter = Math.floor(now.getMonth() / 3) + 1;
-            return { year: now.getFullYear(), quarter };
+            return getQuarterInfo(new Date());
         }
 
         // Obtener inicio del trimestre
         function getQuarterStart(quarter) {
-            const startMonth = (quarter.quarter - 1) * 3;
-            return new Date(quarter.year, startMonth, 1);
+            return quarter.start;
         }
 
         // Obtener fin del trimestre
         function getQuarterEnd(quarter) {
-            const endMonth = quarter.quarter * 3 - 1;
-            const lastDay = new Date(quarter.year, endMonth + 1, 0).getDate();
-            return new Date(quarter.year, endMonth, lastDay);
+            return quarter.end;
         }
 
         // Calcular días hasta fin de trimestre
@@ -675,6 +707,7 @@
             // Configuración
             document.getElementById('creditLimit').value = appState.creditLimit || '';
             document.getElementById('interestRate').value = appState.interestRate || '';
+            document.getElementById('startDate').value = appState.startDate || '';
             
             // Estadísticas
             const currentBalance = calculateCurrentBalance();
@@ -855,10 +888,7 @@
 
         // Obtener siguiente trimestre
         function getNextQuarter(currentQuarter) {
-            if (currentQuarter.quarter === 4) {
-                return { year: currentQuarter.year + 1, quarter: 1 };
-            }
-            return { year: currentQuarter.year, quarter: currentQuarter.quarter + 1 };
+            return getQuarterInfo(addMonths(currentQuarter.start, 3));
         }
 
         // Calcular intereses proyectados


### PR DESCRIPTION
## Summary
- allow specifying a start date for interest calculations
- compute quarters relative to that custom date
- persist the new setting in local storage
- update UI and configuration form

## Testing
- `htmlhint index.html`